### PR TITLE
Test 'exclude_from_schema' deprecation warning message

### DIFF
--- a/rest_framework/schemas/generators.py
+++ b/rest_framework/schemas/generators.py
@@ -150,8 +150,8 @@ class EndpointEnumerator(object):
             return False  # Ignore anything except REST framework views.
 
         if hasattr(callback.cls, 'exclude_from_schema'):
-            fmt = ("{}. The `APIView.exclude_from_schema` is pending deprecation. "
-                   "Set `schema = None` instead")
+            fmt = ("The `{}.exclude_from_schema` is pending deprecation. "
+                   "Set `schema = None` instead.")
             msg = fmt.format(callback.cls.__name__)
             warnings.warn(msg, PendingDeprecationWarning)
             if getattr(callback.cls, 'exclude_from_schema', False):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -690,10 +690,16 @@ class SchemaGenerationExclusionTests(TestCase):
         assert should_include == expected
 
     def test_deprecations(self):
-        with pytest.warns(PendingDeprecationWarning):
+        with pytest.warns(PendingDeprecationWarning) as record:
             @api_view(["GET"], exclude_from_schema=True)
             def view(request):
                 pass
+
+        assert len(record) == 1
+        assert str(record[0].message) == (
+            "The `exclude_from_schema` argument to `api_view` is pending "
+            "deprecation. Use the `schema` decorator instead, passing `None`."
+        )
 
         class OldFashionedExcludedView(APIView):
             exclude_from_schema = True
@@ -706,5 +712,11 @@ class SchemaGenerationExclusionTests(TestCase):
         ]
 
         inspector = EndpointEnumerator(patterns)
-        with pytest.warns(PendingDeprecationWarning):
+        with pytest.warns(PendingDeprecationWarning) as record:
             inspector.get_api_endpoints()
+
+        assert len(record) == 1
+        assert str(record[0].message) == (
+            "The `OldFashionedExcludedView.exclude_from_schema` is "
+            "pending deprecation. Set `schema = None` instead."
+        )


### PR DESCRIPTION
Hi @carltongibson - was just trying to recreate the noise from the deprecation warnings on my machine. In the process, also added assertions for the msg.