### PR TITLE
Manual fields suggestions

### DIFF
--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -175,13 +175,16 @@ class AutoSchema(ViewInspector):
 
         self._manual_fields = manual_fields
 
+    def get_manual_fields(self):
+        return self._manual_fields
+
     def get_link(self, path, method, base_url):
         fields = self.get_path_fields(path, method)
         fields += self.get_serializer_fields(path, method)
         fields += self.get_pagination_fields(path, method)
         fields += self.get_filter_fields(path, method)
 
-        fields = self.update_fields(fields, self._manual_fields)
+        fields = self.update_fields(fields, self.get_manual_fields())
 
         if fields and any([field.location in ('form', 'body') for field in fields]):
             encoding = self.get_encoding(path, method)

--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -117,6 +117,9 @@ def update_fields(fields, update_with):
     * `fields`: list of `coreapi.Field` instances to update
     * `update_with: list of `coreapi.Field` instances to add or replace.
     """
+    if not update_with:
+        return fields
+
     by_name = OrderedDict((f.name, f) for f in fields)
     for f in update_with:
         by_name[f.name] = f
@@ -398,9 +401,7 @@ class AutoSchema(ViewInspector):
         """
         Adjust `fields` with `manual_fields`
         """
-        if self._manual_fields is not None:
-            fields = update_fields(fields, self._manual_fields)
-        return fields
+        return update_fields(fields, self._manual_fields)
 
     def get_encoding(self, path, method):
         """

--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -117,7 +117,7 @@ def update_fields(fields, update_with):
     * `fields`: list of `coreapi.Field` instances to update
     * `update_with: list of `coreapi.Field` instances to add or replace.
     """
-    by_name = {f.name: f for f in fields}
+    by_name = OrderedDict((f.name, f) for f in fields)
     for f in update_with:
         by_name[f.name] = f
     fields = list(by_name.values())

--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -175,16 +175,14 @@ class AutoSchema(ViewInspector):
 
         self._manual_fields = manual_fields
 
-    def get_manual_fields(self):
-        return self._manual_fields
-
     def get_link(self, path, method, base_url):
         fields = self.get_path_fields(path, method)
         fields += self.get_serializer_fields(path, method)
         fields += self.get_pagination_fields(path, method)
         fields += self.get_filter_fields(path, method)
 
-        fields = self.update_fields(fields, self.get_manual_fields())
+        manual_fields = self.get_manual_fields(path, method)
+        fields = self.update_fields(fields, manual_fields)
 
         if fields and any([field.location in ('form', 'body') for field in fields]):
             encoding = self.get_encoding(path, method)
@@ -377,6 +375,9 @@ class AutoSchema(ViewInspector):
         for filter_backend in self.view.filter_backends:
             fields += filter_backend().get_schema_fields(self.view)
         return fields
+
+    def get_manual_fields(self, path, method):
+        return self._manual_fields
 
     @staticmethod
     def update_fields(fields, update_with):

--- a/rest_framework/schemas/inspectors.py
+++ b/rest_framework/schemas/inspectors.py
@@ -105,28 +105,6 @@ def get_pk_description(model, model_field):
     )
 
 
-def update_fields(fields, update_with):
-    """
-    Update list of coreapi.Field instances, overwriting on `Field.name`.
-
-    Utility function to handle replacing coreapi.Field fields
-    from a list by name. Used to handle `manual_fields`.
-
-    Parameters:
-
-    * `fields`: list of `coreapi.Field` instances to update
-    * `update_with: list of `coreapi.Field` instances to add or replace.
-    """
-    if not update_with:
-        return fields
-
-    by_name = OrderedDict((f.name, f) for f in fields)
-    for f in update_with:
-        by_name[f.name] = f
-    fields = list(by_name.values())
-    return fields
-
-
 class ViewInspector(object):
     """
     Descriptor class on APIView.
@@ -203,7 +181,7 @@ class AutoSchema(ViewInspector):
         fields += self.get_pagination_fields(path, method)
         fields += self.get_filter_fields(path, method)
 
-        fields = self.update_manual_fields(fields)
+        fields = self.update_fields(fields, self._manual_fields)
 
         if fields and any([field.location in ('form', 'body') for field in fields]):
             encoding = self.get_encoding(path, method)
@@ -397,11 +375,27 @@ class AutoSchema(ViewInspector):
             fields += filter_backend().get_schema_fields(self.view)
         return fields
 
-    def update_manual_fields(self, fields):
+    @staticmethod
+    def update_fields(fields, update_with):
         """
-        Adjust `fields` with `manual_fields`
+        Update list of coreapi.Field instances, overwriting on `Field.name`.
+
+        Utility function to handle replacing coreapi.Field fields
+        from a list by name. Used to handle `manual_fields`.
+
+        Parameters:
+
+        * `fields`: list of `coreapi.Field` instances to update
+        * `update_with: list of `coreapi.Field` instances to add or replace.
         """
-        return update_fields(fields, self._manual_fields)
+        if not update_with:
+            return fields
+
+        by_name = OrderedDict((f.name, f) for f in fields)
+        for f in update_with:
+            by_name[f.name] = f
+        fields = list(by_name.values())
+        return fields
 
     def get_encoding(self, path, method):
         """


### PR DESCRIPTION
Hi @carltongibson, it's sometimes easier to just write code than to try and explain my thoughts 😄. Anyway, changes are...

One fix:

- Use `OrderedDict` to preserve the order of the fields.

Three suggestions with my opinions on each:

- (+1) The empty check should be in `update_fields()`, as it's not really specific to manual fields.
- (+0) With the above, `update_manual_fields()` becomes a simple hook to call `update_fields()`. Remove `update_manual_fields()` in favor of an `update_fields()` staticmethod. 
- (-0) Add `get_manual_fields()`. This doesn't really seem necessary, as users can override `_manual_fields` in the `__init__`. That said, still worth considering.

That all said, I have little experience with schema generation and have focused on other areas of the framework. I'm not really familiar with the use cases and don't know what's more sensible as an API. 